### PR TITLE
pin ivy and swiper to melpa

### DIFF
--- a/init.el
+++ b/init.el
@@ -35,6 +35,7 @@
         (ido-completing-read+ . "melpa-stable")
         (ido-ubiquitous . "melpa-stable")
         (ido-vertical-mode . "melpa-stable")
+        (ivy . "melpa")
         (flycheck-pos-tip . "melpa-stable")
         (flycheck . "melpa-stable")
         (highlight . "melpa") ;; woo! from the wiki https://www.emacswiki.org/emacs/highlight.el
@@ -52,7 +53,7 @@
         (s . "melpa-stable")
         (seq . "elpa")
         (smex . "melpa-stable")
-        (swiper . "melpa-stable")
+        (swiper . "melpa")
         (use-package . "melpa-stable")
         (with-editor . "melpa-stable")
         (yasnippet . "melpa-stable")))


### PR DESCRIPTION
when ivy came from melpa and swiper came from melpa-stable, it broke swiper. Having both ivy and swiper from melpa-stable didn't work, as the relevant ivy version seems to have disappeared from melpa-stable. Having both libs loaded from melpa works.
